### PR TITLE
update to current boost versions

### DIFF
--- a/fiberize/include/fiberize/context.hpp
+++ b/fiberize/include/fiberize/context.hpp
@@ -11,6 +11,8 @@
 
 #include <fiberize/fiberref.hpp>
 #include <fiberize/spinlock.hpp>
+#include <random>
+
 
 namespace fiberize {
 

--- a/fiberize/include/fiberize/detail/multitaskscheduler.hpp
+++ b/fiberize/include/fiberize/detail/multitaskscheduler.hpp
@@ -8,6 +8,8 @@
 #define FIBERIZE_DETAIL_MULTITASKSCHEDULER_HPP
 
 #include <thread>
+#include <boost/context/stack_context.hpp>
+#include <boost/context/fixedsize_stack.hpp>
 
 #include <fiberize/scheduler.hpp>
 
@@ -61,7 +63,7 @@ private:
     static void unownedLoop();
 
     struct UnownedContext {
-        boost::context::fcontext_t context;
+        boost::context::detail::fcontext_t context;
         boost::context::stack_context stack;
     };
 
@@ -69,7 +71,7 @@ private:
     Task* suspendingTask;
     Task* currentTask_;
     UnownedContext* unowned;
-    boost::context::fcontext_t initialContext;
+    boost::context::detail::fcontext_t initialContext;
 
     std::vector<UnownedContext*> stash;
     UnownedContext* stashGet();

--- a/fiberize/include/fiberize/detail/task.hpp
+++ b/fiberize/include/fiberize/detail/task.hpp
@@ -21,7 +21,7 @@
 #include <mutex>
 
 #include <boost/atomic/atomic.hpp>
-#include <boost/context/all.hpp>
+#include <boost/context/detail/fcontext.hpp>
 #include <boost/smart_ptr/detail/spinlock.hpp>
 
 namespace fiberize {
@@ -137,7 +137,7 @@ public:
     /**
      * The last saved context.
      */
-    boost::context::fcontext_t context;
+    boost::context::detail::fcontext_t context;
 
     /**
      * Tracks how many times there was an attempt to resume this task.

--- a/fiberize/include/fiberize/fibersystem.hpp
+++ b/fiberize/include/fiberize/fibersystem.hpp
@@ -4,7 +4,7 @@
 #include <utility>
 #include <type_traits>
 
-#include <boost/context/all.hpp>
+#include <boost/context/detail/fcontext.hpp>
 #include <boost/type_traits.hpp>
 
 #include <fiberize/promise.hpp>

--- a/fiberize/src/fiberize/fibersystem.cpp
+++ b/fiberize/src/fiberize/fibersystem.cpp
@@ -21,9 +21,7 @@ FiberSystem::FiberSystem(uint32_t macrothreads)
      * Generate the uuid.
      */
     std::uniform_int_distribution<uint64_t> seedDist;
-    boost::random::mt19937 pseudorandom(seedDist(seedGenerator));
-    boost::uuids::random_generator uuidGenerator(pseudorandom);
-    uuid_ = uuidGenerator();
+    uuid_ = boost::uuids::random_generator()();
 
     // Spawn the schedulers.
     for (uint32_t i = 0; i < macrothreads; ++i) {

--- a/fiberize/src/fiberize/path.cpp
+++ b/fiberize/src/fiberize/path.cpp
@@ -1,6 +1,7 @@
 #include <fiberize/path.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <iostream>
+#include <atomic>
 
 namespace fiberize {
 
@@ -11,7 +12,7 @@ std::atomic<uint64_t> generators(0);
 } // namespace detail
 
 UniqueIdentGenerator::UniqueIdentGenerator()
-    : generatorId(std::atomic_fetch_add(&detail::generators, 1ul))
+    : generatorId(std::atomic_fetch_add(&detail::generators, 1ull))
     , nextToken(0)
     {}
 


### PR DESCRIPTION
I've tried to make this work with the current boost version (1.69.0). Unfortunately, after compiling, I get a segfault (11) when executing any of the examples. I've tried stack tracing (dtruss on mac), but this seemed to go a bit too far down the rabbit hole. If anyone finds out how to make this work, please let me know.